### PR TITLE
Fix sidebar error logging and error panel visibility

### DIFF
--- a/ErrorLogPanelComponent.html
+++ b/ErrorLogPanelComponent.html
@@ -1,5 +1,5 @@
 <!-- This file includes embedded JS/CSS due to project type rules -->
-<div id="error-log-panel" role="log" aria-live="polite" aria-atomic="true" aria-label="Error Log"></div>
+<div id="error-log-panel" role="log" aria-live="polite" aria-atomic="true" aria-label="Error Log" style="display:none;"></div>
 <script>
 (function(){
   'use strict';
@@ -16,6 +16,7 @@
     entry.className = 'error-log-entry';
     entry.textContent = String(message);
     panel.appendChild(entry);
+    panel.style.display = 'block';
     panel.scrollTop = panel.scrollHeight;
   }
 
@@ -25,6 +26,7 @@
       throw new Error('ErrorLogPanel.clearLog: Error log panel element not found');
     }
     panel.innerHTML = '';
+    panel.style.display = 'none';
   }
 
   window.ErrorLogPanel = {
@@ -48,6 +50,7 @@
     overflow-y: auto;
     font-family: 'Roboto', sans-serif;
     font-size: 14px;
+    display: none;
   }
   .error-log-entry {
     color: #FF5252;

--- a/SidebarHandler.html
+++ b/SidebarHandler.html
@@ -133,6 +133,11 @@
 
           if (result.invalidRows && result.invalidRows.length) {
             google.script.run.highlightInvalidRows(result.invalidRows);
+            if (typeof appendLog === 'function') {
+              result.invalidRows.forEach(function(r) {
+                appendLog('Invalid URL in row ' + r);
+              });
+            }
             if (typeof hideSpinner === 'function') {
               hideSpinner();
             }
@@ -160,7 +165,10 @@
         }
         enableButtons();
         if (summary && summary.errors && summary.errors.length && typeof appendLog === 'function') {
-          appendLog(summary.errors);
+          summary.errors.forEach(function(err) {
+            var msg = 'Row ' + err.row + ': ' + err.message;
+            appendLog(msg);
+          });
         }
         var msg = 'Scraping complete';
         if (summary && typeof summary.successCount === 'number' && typeof summary.totalCount === 'number') {


### PR DESCRIPTION
## Summary
- hide the error log panel on load and show/hide it as messages are added/cleared
- log invalid URL rows in the sidebar when validation fails
- display individual scrape errors in the sidebar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844946186ec8327a78db70915ca3b4f